### PR TITLE
Allow to change path to access imgproxy

### DIFF
--- a/incubator/imgproxy/templates/ingress.yaml
+++ b/incubator/imgproxy/templates/ingress.yaml
@@ -26,8 +26,10 @@ spec:
   - host: {{ .Values.ingress.host }}
     http:
       paths:
-      - path: /
+      {{- range $path := .Values.ingress.paths }}
+      - path: {{ $path }}
         backend:
-          serviceName: {{ template "imgproxy.fullname" . }}
+          serviceName: {{ template "imgproxy.fullname" $ }}
           servicePort: 80
+      {{- end -}}
 {{- end -}}

--- a/incubator/imgproxy/values.yaml
+++ b/incubator/imgproxy/values.yaml
@@ -54,6 +54,8 @@ ingress:
   acme: false
   host: "example.com"
   annotations: {}
+  paths:
+    - "/"
   #   nginx.ingress.kubernetes.io/proxy-body-size: "32m"
 
 # TLS key & certificate if tls is enable & acme is disabled for Ingress resource.


### PR DESCRIPTION
This allows to mount imgproxy to subpath of main application.

E.g. with following configuration in `values.yaml`:

```yaml
imgproxy:
  ingress:
    annotations:
      nginx.ingress.kubernetes.io/rewrite-target: "/"
    paths:
      - "/"
      - "/images/"
```

Request sent to the `awesome.app/images/signature/options/plain/url` will be received by imgproxy as `/signature/options/plain/url`
